### PR TITLE
register block extension consistently

### DIFF
--- a/src/asciidoctor-plantuml.js
+++ b/src/asciidoctor-plantuml.js
@@ -42,7 +42,7 @@ module.exports.register = function register (registry) {
       this.block(plantumlBlock)
     })
   } else if (typeof registry.block === 'function') {
-    registry.block('plantuml', plantumlBlock)
+    registry.block(plantumlBlock)
   }
   return registry
 }


### PR DESCRIPTION
In one case, an explicit name was being used. In the other case, it was not.