### PR TITLE
Resolves #41, Remove ancillary chunks in the generated PNG file

### DIFF
--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -87,7 +87,11 @@ describe('diagram fetching', () => {
           expect(src).toEndWith('.svg')
           expect(path.basename(src)).toBe(src)
           expect(fs.existsSync(src)).toBe(true)
-          const hash = await hasha.fromFile(src, {algorithm: 'md5'})
+
+          const data = fs.readFileSync(src, 'utf8')
+            // remove comments (otherwise the md5sum won't be stable)
+            .replace(/<!--[\s\S]*?-->/g, '')
+          const hash = hasha(data, {algorithm: 'md5'})
           expect(hash).toBe(fixture.svgHash)
           const svgContent = fs.readFileSync(src, 'utf-8')
             .replace(/\r/gm, '')

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -4,12 +4,17 @@ const tmp = require('tmp')
 const path = require('path')
 
 const hasha = require('hasha')
+const png = require('./png-metadata.js')
 const asciidoctorPlantuml = require('../src/asciidoctor-plantuml.js')
 const asciidoctor = require('asciidoctor.js')()
 tmp.setGracefulCleanup()
 
 const shared = require('./shared.js')
 shared.run() // Run shared tests
+
+const md5sum = str => {
+  return hasha(png.removeAncillaryChunks(str), {algorithm: 'md5'})
+}
 
 describe('diagram fetching', () => {
   let src
@@ -40,7 +45,7 @@ describe('diagram fetching', () => {
       expect(catalog[0].basename).toEndWith('.png') // REMIND: basename is a random string
       expect(catalog[0].relative).toBe('.')
       expect(catalog[0].mediaType).toBe('image/png')
-      const hash = hasha(catalog[0].contents, {algorithm: 'md5'})
+      const hash = md5sum(catalog[0].contents.toString('binary'), {algorithm: 'md5'})
       expect(hash).toBe(fixture.pngHash)
     })
   })
@@ -49,19 +54,18 @@ describe('diagram fetching', () => {
     const fixture = shared.FIXTURES[name]
     const inputFn = shared.asciidocContent(fixture)
     describe(fixture.title, () => {
-      it('should by default fetch PNG when :plantuml-fetch-diagram: set', async () => {
+      it('should by default fetch PNG when :plantuml-fetch-diagram: set', () => {
         const html = shared.toJQueryDOM(inputFn([`:plantuml-server-url: ${shared.PLANTUML_REMOTE_URL}`, ':plantuml-fetch-diagram:']))
 
         src = html('.imageblock.plantuml img').attr('src')
-
         expect(src).toEndWith('.png')
         expect(path.basename(src)).toBe(src)
         expect(fs.existsSync(src)).toBe(true)
-        const hash = await hasha.fromFile(src, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(src, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
 
-      it('should fetch PNG when positional attr :format: is png', async () => {
+      it('should fetch PNG when positional attr :format: is png', () => {
         const html = shared.toJQueryDOM(inputFn([`:plantuml-server-url: ${shared.PLANTUML_REMOTE_URL}`, ':plantuml-fetch-diagram:'], ['test,png']))
 
         src = html('.imageblock.plantuml img').attr('src')
@@ -69,7 +73,7 @@ describe('diagram fetching', () => {
         expect(src).toEndWith('.png')
         expect(path.basename(src)).toBe(src)
         expect(fs.existsSync(src)).toBe(true)
-        const hash = await hasha.fromFile(src, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(src, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
 
@@ -96,7 +100,7 @@ describe('diagram fetching', () => {
         })
       }
 
-      it('should fetch to named file when positional attr :target: is set', async () => {
+      it('should fetch to named file when positional attr :target: is set', () => {
         const html = shared.toJQueryDOM(inputFn([`:plantuml-server-url: ${shared.PLANTUML_REMOTE_URL}`, ':plantuml-fetch-diagram:'], ['myFile']))
 
         src = html('.imageblock.plantuml img').attr('src')
@@ -104,7 +108,7 @@ describe('diagram fetching', () => {
         expect(src).toBe('myFile.png')
         expect(path.basename(src)).toBe(src)
         expect(fs.existsSync(src)).toBe(true)
-        const hash = await hasha.fromFile(src, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(src, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
 
@@ -122,7 +126,7 @@ describe('diagram fetching', () => {
         expect(path.basename(src)).toBe(src)
         const diagramPath = path.format({dir: missingDir, base: src})
         expect(fs.existsSync(diagramPath)).toBe(true)
-        const hash = await hasha.fromFile(diagramPath, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(diagramPath, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
 
@@ -138,7 +142,7 @@ describe('diagram fetching', () => {
         expect(src).toStartWith('_images')
         expect(src).toEndWith('.png')
         expect(fs.existsSync(src)).toBe(true)
-        const hash = await hasha.fromFile(src, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(src, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
 
@@ -157,7 +161,7 @@ describe('diagram fetching', () => {
         expect(src).toEndWith('.png')
         const diagramPath = path.format({dir: dir, base: src})
         expect(fs.existsSync(diagramPath)).toBe(true)
-        const hash = await hasha.fromFile(diagramPath, {algorithm: 'md5'})
+        const hash = md5sum(fs.readFileSync(diagramPath, 'binary'))
         expect(hash).toBe(fixture.pngHash)
       })
     })

--- a/test/png-metadata.js
+++ b/test/png-metadata.js
@@ -1,0 +1,87 @@
+// Adapted from https://github.com/kujirahand/node-png-metadata/blob/master/src/lib/png-metadata.js
+// Fix an iteration issue in the 'joinChunk' function
+
+// PNG File format: https://en.wikipedia.org/wiki/Portable_Network_Graphics#File_format
+const PNG_SIG = String.fromCharCode(0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a)
+
+// check PNG signature
+const isPNG = function (str) {
+  const sig = str.substr(0, 8)
+  return (sig === PNG_SIG)
+}
+
+const extractChunks = function (str) {
+  // read signature
+  const sig = str.substr(0, 8)
+  if (!isPNG(sig)) return false
+  str = str.substr(8) // chomp sig
+  const chunks = []
+  // read chunk list
+  while (str !== '') {
+    const chunk = {}
+    // read chunk size
+    let size = stoi(str.substr(0, 4))
+    if (size < 0) {
+      // If the size is negative, the data is likely corrupt, but we'll let
+      // the caller decide if any of the returned chunks are usable.
+      // We'll move forward in the file with the minimum chunk length (12 bytes).
+      size = 0
+    }
+    const buf = str.substr(0, size + 12)
+    str = str.substr(size + 12) // delete this chunk
+    // read chunk data
+    chunk.size = size
+    chunk.type = buf.substr(4, 4)
+    chunk.data = buf.substr(8, size)
+    chunk.crc = stoi(buf.substr(8 + size, 4))
+    // add chunk
+    chunks.push(chunk)
+  }
+  return chunks
+}
+
+const joinChunks = function (chunks) {
+  let pf = PNG_SIG
+  for (let chunk of chunks) {
+    let buf = ''
+    buf += itos(chunk.size, 4)
+    buf += chunk.type
+    buf += chunk.data
+    buf += itos(chunk.crc, 4)
+    pf += buf
+  }
+  return pf
+}
+
+const itos = (v, size) => {
+  let a = []
+  let t = size - 1
+  while (t >= 0) {
+    a[t--] = v & 0xFF
+    v = v >> 8
+  }
+  a = a.map(function (v) {
+    return String.fromCharCode(v)
+  })
+  return a.join('')
+}
+
+const stoi = (str) => {
+  let v = 0
+  for (let i = 0; i < str.length; i++) {
+    const c = str.charCodeAt(i)
+    v = (v << 8) | (c & 0xFF)
+  }
+  return v
+}
+
+const removeAncillaryChunks = str => {
+  const chunks = extractChunks(str)
+  // keep only the critical chunks (ie. remove all the ancillary chunks)
+  const criticalChunks = chunks.filter(chunk => chunk.type === 'IHDR' || chunk.type === 'PLTE' || chunk.type === 'IDAT' || chunk.type === 'IEND')
+  return joinChunks(criticalChunks)
+}
+
+module.exports = {
+  removeAncillaryChunks
+}

--- a/test/shared.js
+++ b/test/shared.js
@@ -17,7 +17,7 @@ sharedSpec.FIXTURES = {
 alice -> bob
 @enduml`,
     pngHash: '5df44d9d739236262f5746860182827e',
-    svgHash: '4c7ee8a961ddb85715a427d5d51247fa',
+    svgHash: '06c71ae4ec8e45fd06f1def8ac0c2e2a',
     hasStartEndDirectives: true,
     format: 'plantuml'
   },
@@ -28,7 +28,7 @@ alice -> bob
 bob ..> alice
 `,
     pngHash: '5894d1cd6f399cf084b18be8e4010c50',
-    svgHash: 'e4f1000fdee0da37f65e49279d0e8d31',
+    svgHash: 'ae2b19469c19be7e61ff88f9696cb159',
     hasStartEndDirectives: false,
     format: 'plantuml'
   },
@@ -59,7 +59,7 @@ digraph foo {
 }
 `,
     pngHash: '630e0e1b38a2334468af5b6d489d73b7',
-    svgHash: '8c760726ad7ae0bd58ababb53a2ee54a',
+    svgHash: '2e12082a2099d334ca8f306e06f77f52',
     hasStartEndDirectives: false,
     format: 'graphviz'
   }

--- a/test/shared.js
+++ b/test/shared.js
@@ -16,7 +16,7 @@ sharedSpec.FIXTURES = {
     source: `@startuml
 alice -> bob
 @enduml`,
-    pngHash: 'c83dfd7ca39e84d43980940308c7f554',
+    pngHash: '5df44d9d739236262f5746860182827e',
     svgHash: '4c7ee8a961ddb85715a427d5d51247fa',
     hasStartEndDirectives: true,
     format: 'plantuml'
@@ -27,7 +27,7 @@ alice -> bob
 alice -> bob
 bob ..> alice
 `,
-    pngHash: '62f0d0672deb706c7cbff27df2a4ce1e',
+    pngHash: '5894d1cd6f399cf084b18be8e4010c50',
     svgHash: 'e4f1000fdee0da37f65e49279d0e8d31',
     hasStartEndDirectives: false,
     format: 'plantuml'
@@ -42,7 +42,7 @@ bob ..> alice
 |       {s}|   +-------------+
 +----------+
 `,
-    pngHash: '44ab1d8bee2efd5c7ad6104052ae08c2',
+    pngHash: '4849113f73546151997ea02cf32831d5',
     hasStartEndDirectives: false,
     format: 'ditaa'
   },
@@ -58,7 +58,7 @@ digraph foo {
   node1 -> node2 -> node3
 }
 `,
-    pngHash: '56616a6dc2fa9859f0cce7f3f1e6c546',
+    pngHash: '630e0e1b38a2334468af5b6d489d73b7',
     svgHash: '8c760726ad7ae0bd58ababb53a2ee54a',
     hasStartEndDirectives: false,
     format: 'graphviz'


### PR DESCRIPTION
I believe the tests are randomly failing because the PNG file contains "unstable" metadata.
This pull request remove all ancillary chunks to keep only critical chunks: https://en.wikipedia.org/wiki/Portable_Network_Graphics#File_format

With this change, the md5sum should be stable.