### PR TITLE
Resolves #45, use a SHA1 of the diagram URL as basename

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "mkdirp": "^0.5.1",
     "plantuml-encoder": "^1.2.5",
-    "randomstring": "^1.1.5",
+    "rusha": "^0.8.13",
     "sync-request": "^5.0.0"
   },
   "devDependencies": {

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,5 +1,5 @@
 const request = require('sync-request')
-const randomstring = require('randomstring')
+const rusha = require('rusha')
 const path = require('path')
 
 module.exports.save = function (diagramUrl, doc, target, format, vfs) {
@@ -7,7 +7,7 @@ module.exports.save = function (diagramUrl, doc, target, format, vfs) {
     vfs = require('./node-fs')
   }
   const dirPath = path.join(doc.getAttribute('imagesoutdir') || '', doc.getAttribute('imagesdir') || '')
-  const diagramName = `${target || randomstring.generate()}.${format}`
+  const diagramName = `${target || rusha.createHash().update(diagramUrl).digest('hex')}.${format}`
   vfs.add({
     relative: dirPath,
     basename: diagramName,

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -59,6 +59,7 @@ describe('diagram fetching', () => {
 
         src = html('.imageblock.plantuml img').attr('src')
         expect(src).toEndWith('.png')
+        expect(src).toBe(`${fixture.basenameHash}.png`)
         expect(path.basename(src)).toBe(src)
         expect(fs.existsSync(src)).toBe(true)
         const hash = md5sum(fs.readFileSync(src, 'binary'))
@@ -70,7 +71,7 @@ describe('diagram fetching', () => {
 
         src = html('.imageblock.plantuml img').attr('src')
 
-        expect(src).toEndWith('.png')
+        expect(src).toBe('test.png')
         expect(path.basename(src)).toBe(src)
         expect(fs.existsSync(src)).toBe(true)
         const hash = md5sum(fs.readFileSync(src, 'binary'))
@@ -84,7 +85,7 @@ describe('diagram fetching', () => {
 
           src = html('.imageblock.plantuml img').attr('src')
 
-          expect(src).toEndWith('.svg')
+          expect(src).toBe('test.svg')
           expect(path.basename(src)).toBe(src)
           expect(fs.existsSync(src)).toBe(true)
 
@@ -127,6 +128,7 @@ describe('diagram fetching', () => {
         src = html('.imageblock.plantuml img').attr('src')
 
         expect(src).toEndWith('.png')
+        expect(src).toBe(`${fixture.basenameHash}.png`)
         expect(path.basename(src)).toBe(src)
         const diagramPath = path.format({dir: missingDir, base: src})
         expect(fs.existsSync(diagramPath)).toBe(true)
@@ -145,6 +147,7 @@ describe('diagram fetching', () => {
 
         expect(src).toStartWith('_images')
         expect(src).toEndWith('.png')
+        expect(path.basename(src)).toBe(`${fixture.basenameHash}.png`)
         expect(fs.existsSync(src)).toBe(true)
         const hash = md5sum(fs.readFileSync(src, 'binary'))
         expect(hash).toBe(fixture.pngHash)
@@ -163,6 +166,7 @@ describe('diagram fetching', () => {
         src = html('.imageblock.plantuml img').attr('src')
         expect(src).toStartWith('_images')
         expect(src).toEndWith('.png')
+        expect(path.basename(src)).toBe(`${fixture.basenameHash}.png`)
         const diagramPath = path.format({dir: dir, base: src})
         expect(fs.existsSync(diagramPath)).toBe(true)
         const hash = md5sum(fs.readFileSync(diagramPath, 'binary'))

--- a/test/shared.js
+++ b/test/shared.js
@@ -18,6 +18,7 @@ alice -> bob
 @enduml`,
     pngHash: '5df44d9d739236262f5746860182827e',
     svgHash: '06c71ae4ec8e45fd06f1def8ac0c2e2a',
+    basenameHash: 'b4587e8276f29f20288b0d3eef353039fafa610e',
     hasStartEndDirectives: true,
     format: 'plantuml'
   },
@@ -29,6 +30,7 @@ bob ..> alice
 `,
     pngHash: '5894d1cd6f399cf084b18be8e4010c50',
     svgHash: 'ae2b19469c19be7e61ff88f9696cb159',
+    basenameHash: 'b2d6104c24493835888413f7bd423750b044fc7f',
     hasStartEndDirectives: false,
     format: 'plantuml'
   },
@@ -43,6 +45,7 @@ bob ..> alice
 +----------+
 `,
     pngHash: '4849113f73546151997ea02cf32831d5',
+    basenameHash: '2532bdb8c8712b770d870eb65e3fa5a22622fd48',
     hasStartEndDirectives: false,
     format: 'ditaa'
   },
@@ -60,6 +63,7 @@ digraph foo {
 `,
     pngHash: '630e0e1b38a2334468af5b6d489d73b7',
     svgHash: '2e12082a2099d334ca8f306e06f77f52',
+    basenameHash: 'e745ed72ac0f359ce97f95f3b3df87cff5df56f1',
     hasStartEndDirectives: false,
     format: 'graphviz'
   }

--- a/yarn.lock
+++ b/yarn.lock
@@ -272,10 +272,6 @@ array-union@^1.0.1:
   dependencies:
     array-uniq "^1.0.1"
 
-array-uniq@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.2.tgz#5fcc373920775723cfd64d65c64bef53bf9eba6d"
-
 array-uniq@^1.0.1:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/array-uniq/-/array-uniq-1.0.3.tgz#af6ac877a25cc7f74e058894753858dfdb24fdb6"
@@ -5288,12 +5284,6 @@ randomfill@^1.0.3:
     randombytes "^2.0.5"
     safe-buffer "^5.1.0"
 
-randomstring@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/randomstring/-/randomstring-1.1.5.tgz#6df0628f75cbd5932930d9fe3ab4e956a18518c3"
-  dependencies:
-    array-uniq "1.0.2"
-
 range-parser@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.0.tgz#f49be6b487894ddc40dcc94a322f611092e00d5e"
@@ -5717,6 +5707,10 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   resolved "https://registry.yarnpkg.com/run-queue/-/run-queue-1.0.3.tgz#e848396f057d223f24386924618e25694161ec47"
   dependencies:
     aproba "^1.1.1"
+
+rusha@^0.8.13:
+  version "0.8.13"
+  resolved "https://registry.yarnpkg.com/rusha/-/rusha-0.8.13.tgz#9a084e7b860b17bff3015b92c67a6a336191513a"
 
 rx-lite-aggregates@^4.0.8:
   version "4.0.8"


### PR DESCRIPTION
The name of the file is reproductible (stable) and unique.