### PR TITLE
resolves #72 introduce plantuml-default-format asciidoc attribute

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -106,6 +106,9 @@ E.g. `./assets/images`
 |plantuml-config-file
 |Analogue of https://github.com/asciidoctor/asciidoctor-diagram#plantuml[PlantUML config] attribute.
 
+|plantuml-default-format
+|Sets the default output format, which is normally png. This can be overriden in specific diagrams.
+
 |===
 
 == Antora integration

--- a/src/asciidoctor-plantuml.js
+++ b/src/asciidoctor-plantuml.js
@@ -72,7 +72,7 @@ function processPlantuml (processor, parent, attrs, diagramType, diagramText, co
   const title = attrs.title
   if (serverUrl) {
     const target = attrs.target
-    const format = attrs.format || 'png'
+    const format = attrs.format || doc.getAttribute('plantuml-default-format') || 'png'
     if (format === 'png' || format === 'svg') {
       const imageUrl = createImageSrc(doc, diagramText, target, format, context.vfs)
       const blockAttrs = {

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -304,5 +304,24 @@ graphviz::${__dirname}/fixtures/nodes.dot[format=png]`, {extension_registry: reg
       asciidoctor.convert(input, {extension_registry: registry})
       expect(antoraContentCatalog.getFiles().length).toBe(1)
     })
+    it('should honor plantuml-default-format setting', () => {
+      const antoraContentCatalog = new ContentCatalog()
+      const registry = asciidoctorPlantuml.register(asciidoctor.Extensions.create(), {
+        contentCatalog: antoraContentCatalog,
+        file: {
+          src: {
+            component: 'test',
+            version: '1',
+            module: 'testmodule'
+          }
+        }
+      })
+      const fixture = shared.FIXTURES.plantumlWithStartEndDirectives
+      const inputFn = shared.asciidocContent(fixture)
+      const input = inputFn([`:plantuml-server-url: ${shared.PLANTUML_REMOTE_URL}`, ':plantuml-fetch-diagram:', ':plantuml-default-format: svg'])
+      asciidoctor.convert(input, {extension_registry: registry})
+      expect(antoraContentCatalog.getFiles().length).toBe(1)
+      expect(antoraContentCatalog.getFiles()[0].src.basename).toEndWith('.svg')
+    })
   })
 })

--- a/test/shared.js
+++ b/test/shared.js
@@ -286,6 +286,21 @@ Guillaume -> Evgeny
             expect(src).toBe(`${sharedSpec.LOCAL_URL}/svg/${encodedDiagram}`)
           })
 
+          it('should support format from plantuml-default-format', () => {
+            const src = sharedSpec.toJQueryDOM(inputFn([`:plantuml-server-url: ${sharedSpec.LOCAL_URL}`, ':plantuml-default-format: svg'], []))('.imageblock.plantuml img').attr('src')
+            expect(src).toBe(`${sharedSpec.LOCAL_URL}/svg/${encodedDiagram}`)
+          })
+
+          it('should support explicit png format from positional attr overriding :plantuml-default-format: svg', () => {
+            const src = sharedSpec.toJQueryDOM(inputFn([`:plantuml-server-url: ${sharedSpec.LOCAL_URL}`, ':plantuml-default-format: svg'], ['\'\'', 'png']))('.imageblock.plantuml img').attr('src')
+            expect(src).toBe(`${sharedSpec.LOCAL_URL}/png/${encodedDiagram}`)
+          })
+
+          it('should support explicit png format from named attr overriding :plantuml-default-format: svg', () => {
+            const src = sharedSpec.toJQueryDOM(inputFn([`:plantuml-server-url: ${sharedSpec.LOCAL_URL}`, ':plantuml-default-format: svg'], ['format=png']))('.imageblock.plantuml img').attr('src')
+            expect(src).toBe(`${sharedSpec.LOCAL_URL}/png/${encodedDiagram}`)
+          })
+
           if (fixture.hasStartEndDirectives) {
             it('should generate HTML error when unsupported format used', () => {
               const listingBlock = sharedSpec.toJQueryDOM(inputFn([`:plantuml-server-url: ${sharedSpec.LOCAL_URL}`], ['\'\'', 'qwe']))('.listingblock.plantuml-error')


### PR DESCRIPTION
Set the default output format with plantuml-default-format: svg